### PR TITLE
force usage of OpenCV 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_compile_options(-Wall)
 
 find_package(catkin_simple REQUIRED)
 find_package(Ceres REQUIRED)
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 3 REQUIRED)
 
 include_directories(${CERES_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 


### PR DESCRIPTION
We tried building with OpenCV 4 and it failed. We had to force usage of OpenCV 3 in the CMakeLists for it to compile.